### PR TITLE
Change Odometer update rate, refactor speed, grav, atmo displays

### DIFF
--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -146,6 +146,7 @@ handlers:
                 hasAtmoRadar = false
                 damageMessage = [[]]
                 radarMessage = [[]]
+                LastOdometerOutput = ""
                 peris = 0
                 BrakeButtonHovered = false         
                 RetrogradeButtonHovered = false    
@@ -1131,8 +1132,6 @@ handlers:
                     local throt = mfloor(unit.getThrottle())
                     local spd = speed*3.6
                     local flightValue = unit.getAxisCommandValue(0)
-                    local flightType = Nav.axisCommandManager:getAxisCommandType(0)
-                    local flightStyle = "TRAVEL"
                     local rgbO = rgb
                     local rgbdimO = rgbdim
                     local rgbdimmerO = rgbdimmer
@@ -1142,13 +1141,6 @@ handlers:
                             rgbdim = [[rgb(]] .. mfloor(PrimaryR *0.4 + 0.5) .. "," .. mfloor(PrimaryG * 0.4 + 0.5) .. "," .. mfloor(PrimaryB * 0.4 + 0.5) .. [[)]]
                             rgbdimmer = [[rgb(]] .. mfloor(PrimaryR *0.3 + 0.5) .. "," .. mfloor(PrimaryG * 0.3 + 0.5) .. "," .. mfloor(PrimaryB * 0.3 + 0.5) .. [[)]]
                         --end
-                    end
-                    if (flightType == 1) then
-                        flightStyle = "CRUISE"
-
-                    end
-                    if Autopilot then
-                        flightStyle = "AUTOPILOT"
                     end
 
                     if (atmos == 0) then
@@ -1180,11 +1172,16 @@ handlers:
                     
                     -- CRUISE/ODOMETER
 
-                    DrawOdometer(newContent, spd, gravity, totalDistanceTrip, totalDistanceTravelled, flightStyle)
+                    newContent[#newContent + 1] = LastOdometerOutput
+
+                    -- DAMAGE
 
                     newContent[#newContent + 1] = damageMessage
-                    newContent[#newContent + 1] = radarMessage
 
+                    -- RADAR
+
+                    newContent[#newContent + 1] = radarMessage
+                    
                     -- FUEL TANKS
                     
                     if (UpdateCount % FuelUpdateDelay == 0) then updateTanks = true end
@@ -1209,7 +1206,11 @@ handlers:
                         DrawArtificialHorizon(newContent, originalPitch, originalRoll, atmos)
                         DrawRollDisplay(newContent, roll, bottomText)
                         DrawAltitudeDisplay(newContent, altitude, atmos)
-                    end                             
+                    end   
+
+                    -- PRIMARY DATA DISPLAYS
+
+                    DrawSpeedGravityAtmosphere(newContent, spd, gravity, atmos)                          
 
                     -- After the HUD, set RGB values back to undimmed even if view is unlocked
                     rgb = rgbO
@@ -1226,7 +1227,36 @@ handlers:
                     end
                 end
 
-                function DrawOdometer(newContent, spd, gravity, totalDistanceTrip, totalDistanceTravelled, flightStyle)
+                function DrawSpeedGravityAtmosphere(newContent, spd, gravity, atmos)
+                    local ys1 = 375
+                    local ys2 = 390
+                    local xg = 1200
+                    local yg1 = 710
+                    local yg2 = 720
+                    if Nav.control.isRemoteControlled() == 1 then
+                        ys1 = 60
+                        ys2 = 75
+                        xg = 1120
+                        yg1 = 55
+                        yg2 = 65
+                    else -- We only show atmo when not remote
+                        newContent[#newContent + 1] = stringf([[
+                            <text x="770" y="710" text-anchor="end">ATMOSPHERE</text>
+                            <text x="770" y="720" text-anchor="end">%.2f m</text>
+                        </g>]], atmos)
+                    end
+                    newContent[#newContent + 1] = stringf([[
+                        <g class="text">
+                            <g font-size=10>
+                                <text x="960" y="%d" text-anchor="middle" style="fill:%s">SPEED</text>
+                                <text x="960" y="%d" text-anchor="middle" style="fill:%s;font-size:14;">%d km/h</text>
+                                <text x="%d" y="%d" text-anchor="end">GRAVITY</text>
+                                <text x="%d" y="%d" text-anchor="end">%.2f m/s2</text>
+                            </g>
+                        </g>]], ys1, rgbO, ys2, rgbO, mfloor(spd), xg, yg1, xg, yg2, gravity)
+                end
+
+                function DrawOdometer(newContent, totalDistanceTrip, totalDistanceTravelled, flightStyle)
                     local maxBrake = jdecode(unit.getData()).maxBrake
                     if maxBrake ~= nil then LastMaxBrake = maxBrake end
                     maxThrust = Nav:maxForceForward()
@@ -1238,12 +1268,6 @@ handlers:
                     if Nav.control.isRemoteControlled() == 0 then
                         newContent[#newContent + 1] = stringf([[
                             <g class="text">
-                                <g font-size=10>
-                                    <text x="960" y="375" text-anchor="middle" style="fill:%s">SPEED</text>
-                                    <text x="960" y="390" text-anchor="middle" style="fill:%s;font-size:14;">%d km/h</text>
-                                    <text x="1200" y="710" text-anchor="end">GRAVITY</text>
-                                    <text x="1200" y="720" text-anchor="end">%.2f m/s2</text>
-                                </g>
                                 <g font-size=15>
                                     <text x="740" y="20" text-anchor="start" style="fill:%s;font-size:10;">Trip: %.2f km</text>
                                     <text x="740" y="30" text-anchor="start" style="fill:%s;font-size:10;">Lifetime: %.2f Mm</text>
@@ -1252,20 +1276,14 @@ handlers:
                                     <text x="1180" y="30" text-anchor="end" style="fill:%s;font-size:10;">Mass: %.2f Tons</text>
                                     <text x="960" y="33" text-anchor="middle" style="fill:%s">%s</text>
                                 </g>
-                            </g>]], rgbO, rgbO, mfloor(spd), gravity, rgbO, totalDistanceTrip, rgbO, (totalDistanceTravelled/1000), rgb0, (maxThrust/1000), rgbO, (LastMaxBrake/1000), rgb0, (totalMass/1000), rgb0, flightStyle)
+                            </g>]], rgbO, totalDistanceTrip, rgbO, (totalDistanceTravelled/1000), rgb0, (maxThrust/1000), rgbO, (LastMaxBrake/1000), rgb0, (totalMass/1000), rgb0, flightStyle)
                     else -- If remote controlled, draw stuff near the top so it's out of the way
                         newContent[#newContent + 1] = stringf([[
                             <g class="text">
-                                <g font-size=10>
-                                    <text x="960" y="60" text-anchor="middle" style="fill:%s">SPEED</text>
-                                    <text x="960" y="75" text-anchor="middle" style="fill:%s;font-size:14;">%d km/h</text>
-                                    <text x="1120" y="55" text-anchor="end" style="fill:%s">GRAVITY</text>
-                                    <text x="1120" y="65" text-anchor="end" style="fill:%s">%.2f m/s2</text>
-                                </g>
                                 <g font-size=15>
                                     <text x="960" y="33" text-anchor="middle" style="fill:%s">%s</text>
                                 </g>
-                            </g>]], rgbO, rgbO, mfloor(spd), rgbO, rgbO, gravity, rgbO, flightStyle)
+                            </g>]], rgbO, flightStyle)
                     end
                 end
 
@@ -2855,7 +2873,21 @@ handlers:
                         peris = 0
                         ToggleRadarPanel()
                     end
-                end        
+                end 
+
+                -- Update odometer output string
+                local flightType = Nav.axisCommandManager:getAxisCommandType(0)
+                local flightStyle = "TRAVEL"
+                if (flightType == 1) then
+                    flightStyle = "CRUISE"
+                end
+                if Autopilot then
+                    flightStyle = "AUTOPILOT"
+                end
+
+                local newContent = {}
+                DrawOdometer(newContent, totalDistanceTrip, totalDistanceTravelled, flightStyle)       
+                LastOdometerOutput = table.concat(newContent, "")
         tick:
             args: ["msgTick"]
             lua: |
@@ -3634,6 +3666,18 @@ handlers:
         actionStop:
             args: [right]
             lua: rollInput = rollInput - 1
+        actionStart:
+            args: [yawright]
+            lua: yawInput = yawInput - 1
+        actionStop:
+            args: [yawright]
+            lua: yawInput = yawInput + 1
+        actionStart:
+            args: [yawleft]
+            lua: yawInput = yawInput + 1
+        actionStop:
+            args: [yawleft]
+            lua: yawInput = yawInput - 1
 
         actionStart:
             args: [straferight]
@@ -3722,18 +3766,6 @@ handlers:
                 if AltitudeHold then
                     HoldAltitudeButtonModifier = OldButtonMod
                 end
-        actionStart:
-            args: [yawright]
-            lua: yawInput = yawInput - 1
-        actionStop:
-            args: [yawright]
-            lua: yawInput = yawInput + 1
-        actionStart:
-            args: [yawleft]
-            lua: yawInput = yawInput + 1
-        actionStop:
-            args: [yawleft]
-            lua: yawInput = yawInput - 1
         actionStart:
             args: [option1]
             lua: IncrementAutopilotTargetIndex()


### PR DESCRIPTION
Odometer doesn't need to update every frame, so factored that out to only update once per second.
Speed, gravity and atmosphere displays are now in their own function, not spread across several.
Moved yaw updates to be co-located with other keyboard flight control updates (no functional change)