### PR TITLE
Add FPS limiter for HUD

### DIFF
--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -94,6 +94,7 @@ handlers:
                 speedChangeSmall = 1 --export: the speed change that occurs while you hold speed up/down, default is 1 (5% throttle change).
                 brightHud = false --export: Enable to prevent hud dimming when in freelook.
                 brakeLandingRate = 30 --export: Max loss of altitude speed in m/s when doing a brake landing, default 30.  This is to prevent "bouncing" as hover/boosters catch you.  Do not use negative number.
+                HUDFPS = 60 --export: The maximum framerate to draw the HUD at.  If you get significant FPS drops with the HUD on, lower this number.
 
 
                 -- GLOBAL VARIABLES SECTION, IF NOT USED OUTSIDE UNIT.START, MAKE IT LOCAL
@@ -119,7 +120,8 @@ handlers:
                 AltitudeHold = false
                 AutoLanding = false
                 BrakeLanding = false
-                AutoTakeoff = false
+                AutoTakeoff = false                
+                NextDrawTime = system.getTime()
                 HoldAltitude = 1000 -- In case something goes wrong, give this a decent start value
                 AutopilotAccelerating = false
                 AutopilotBraking = false
@@ -3202,17 +3204,25 @@ handlers:
 
                 end
                 newContent[#newContent + 1] = [[</svg></body>]]
-                local content = table.concat(newContent, "")
-                if content ~= LastContent then
-                    --if isRemote() == 1 and screen_1 then -- Once the screens are fixed we can do this.
-                    --    screen_1.setHTML(content) -- But also this is disgusting and the resolution's terrible.  We're doing something wrong.
-                    --else
-                    if not Animating then
-                        system.setScreen(content)
+                
+                local now = system.getTime()
+                if now > NextDrawTime then
+                    local content = table.concat(newContent, "")
+                    if content ~= LastContent then
+                        --if isRemote() == 1 and screen_1 then -- Once the screens are fixed we can do this.
+                        --    screen_1.setHTML(content) -- But also this is disgusting and the resolution's terrible.  We're doing something wrong.
+                        --else
+                        if not Animating then
+                            system.setScreen(content)
+                        end
+                        --end
                     end
-                    --end
+                    LastContent = content
+                    NextDrawTime = now + 1.0/HUDFPS
                 end
-                LastContent = content
+                
+                
+
                 if AutoBrake and AutopilotTargetPlanetName ~= "None" and (vec3(core.getConstructWorldPos())-vec3(AutopilotTargetPlanet.center)):len() <= brakeDistance then
                     brakeInput = 1
                     if planet.name == AutopilotTargetPlanet.name and orbit.apoapsis ~= nil and orbit.eccentricity < 1 then


### PR DESCRIPTION
FPS limiter allows us to dial back how often we call setScreen, which itself causes serious performance issues.  The less often we call this, the better the overall game framerate, but the less frequently we show changes to the HUD.  Users may adjust the value down to suit their tradeoff.