### PR TITLE
Fuel tank fixes.

### DIFF
--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -78,7 +78,9 @@ handlers:
                 autoRollPreference = false --export: [Only in atmosphere]<br>When the pilot stops rolling,  flight model will try to get back to horizontal (no roll)
                 showHud = true --export: Uncheck to hide the HUD and only use autopilot features via ALT+# keys.
                 hideHudOnToggleWidgets = true --export: Uncheck to keep showing HUD when you toggle on the widgets via ALT+3.
-                fuelTankOptimization = 0 --export: For accurate fuel levels, set this to the fuel tank optimization level * 0.05 (so level 1 = 0.05, level 5 = 0.25) of the person who placed the tank. This will be 0 for most people for now.
+                fuelTankOptimizationAtmo = 0 --export: For accurate estimates, set this to the fuel tank optimization level of the person who placed the element. Ignored for slotted tanks.
+                fuelTankOptimizationSpace = 0 --export: For accurate estimates, set this to the fuel tank optimization level of the person who placed the element. Ignored for slotted tanks.
+                fuelTankOptimizationRocket = 0 --export: For accurate estimates, set this to the fuel tank optimization level of the person who placed the element. Ignored for slotted tanks.
                 RemoteFreeze = false --export: Whether or not to freeze you when using a remote controller.  Breaks some things, only freeze on surfboards
                 pitchSpeedFactor = 0.8 --export: For keyboard control
                 yawSpeedFactor =  1 --export: For keyboard control
@@ -287,7 +289,9 @@ handlers:
                     "AutopilotInterplanetaryThrottle",
                     "hideHudOnToggleWidgets",
                     "DampingMultiplier",
-                    "fuelTankOptimization",
+                    "fuelTankOptimizationAtmo",
+                    "fuelTankOptimizationSpace",
+                    "fuelTankOptimizationRocket",
                     "RemoteFreeze",
                     "speedChangeLarge",
                     "speedChangeSmall",
@@ -390,11 +394,11 @@ handlers:
                                 massEmpty = 182.67
                             end
                             curMass = mass - massEmpty
+                            if fuelTankOptimizationAtmo > 0 then 
+                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*(fuelTankOptimizationAtmo*0.2))
+                            end
                             if curMass > vanillaMaxVolume then 
                                 vanillaMaxVolume = curMass
-                            end
-                            if fuelTankOptimization > 0 then 
-                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*fuelTankOptimization)
                             end
                             atmoTanks[#atmoTanks + 1] = {elementsID[k], core.getElementNameById(elementsID[k]), vanillaMaxVolume, massEmpty, curMass, curTime}
                         end
@@ -412,17 +416,17 @@ handlers:
                                 massEmpty = 886.72
                             end
                             curMass = mass - massEmpty
+                            if fuelTankOptimizationRocket > 0 then 
+                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*(fuelTankOptimizationRocket*0.1))
+                            end
                             if curMass > vanillaMaxVolume then 
                                 vanillaMaxVolume = curMass
-                            end
-                            if fuelTankOptimization > 0 then 
-                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*fuelTankOptimization)
                             end
                            rocketTanks[#rocketTanks + 1] = {elementsID[k], core.getElementNameById(elementsID[k]), vanillaMaxVolume, massEmpty, curMass, curTime}
                         end
                         if (name == "space fuel-tank") then 
                             local vanillaMaxVolume = 2400
-                            local massEmpty = 187.67
+                            local massEmpty = 182.67
                             if hp > 10000 then 
                                 vanillaMaxVolume = 76800 -- volume in kg of L tank
                                 massEmpty = 5480
@@ -431,11 +435,11 @@ handlers:
                                 massEmpty = 988.67
                             end
                             curMass = mass - massEmpty
+                            if fuelTankOptimizationSpace > 0 then 
+                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*(fuelTankOptimizationSpace*0.2))
+                            end
                             if curMass > vanillaMaxVolume then 
                                 vanillaMaxVolume = curMass
-                            end
-                            if fuelTankOptimization > 0 then 
-                                vanillaMaxVolume = vanillaMaxVolume + (vanillaMaxVolume*fuelTankOptimization)
                             end
                             spaceTanks[#spaceTanks + 1] = {elementsID[k], core.getElementNameById(elementsID[k]), vanillaMaxVolume, massEmpty, curMass, curTime}
                         end
@@ -1071,7 +1075,7 @@ handlers:
                                 local curTime = system.getTime()
                                 if slottedTanks > 0 then
                                     for j = 1, slottedTanks do
-                                        if name == string.sub(json.decode(unit[slottedTankType.."_"..j].getData()).name, 1, 12) then
+                                        if tankTable[i][tankName] == json.decode(unit[slottedTankType.."_"..j].getData()).name then
                                             fuelPercentTable[i] = json.decode(unit[slottedTankType.."_"..j].getData()).percentage
                                             fuelTimeLeftTable[i] = json.decode(unit[slottedTankType.."_"..j].getData()).timeLeft
                                             if fuelTimeLeftTable[i] == "n/a" then fuelTimeLeftTable[i] = 0 end

--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -422,7 +422,7 @@ handlers:
                             if curMass > vanillaMaxVolume then 
                                 vanillaMaxVolume = curMass
                             end
-                           rocketTanks[#rocketTanks + 1] = {elementsID[k], core.getElementNameById(elementsID[k]), vanillaMaxVolume, massEmpty, curMass, curTime}
+                            rocketTanks[#rocketTanks + 1] = {elementsID[k], core.getElementNameById(elementsID[k]), vanillaMaxVolume, massEmpty, curMass, curTime}
                         end
                         if (name == "space fuel-tank") then 
                             local vanillaMaxVolume = 2400
@@ -1066,33 +1066,33 @@ handlers:
                     if (#tankTable > 0) then
                         for i = 1, #tankTable do
                             local name = string.sub(tankTable[i][tankName], 1, 12)
+                            local slottedIndex = 0
+                            for j = 1, slottedTanks do
+                                if tankTable[i][tankName] == json.decode(unit[slottedTankType.."_"..j].getData()).name then
+                                    slottedIndex = j
+                                    break
+                                end
+                            end
                             if updateTanks or fuelTimeLeftTable[i] == nil or fuelPercentTable[i] == nil then
                                 local fuelMassMax = 0
                                 local fuelMassLast = 0
                                 local fuelMass = 0
                                 local fuelLastTime = 0
-                                local foundTank = false
                                 local curTime = system.getTime()
-                                if slottedTanks > 0 then
-                                    for j = 1, slottedTanks do
-                                        if tankTable[i][tankName] == json.decode(unit[slottedTankType.."_"..j].getData()).name then
-                                            fuelPercentTable[i] = json.decode(unit[slottedTankType.."_"..j].getData()).percentage
-                                            fuelTimeLeftTable[i] = json.decode(unit[slottedTankType.."_"..j].getData()).timeLeft
-                                            if fuelTimeLeftTable[i] == "n/a" then fuelTimeLeftTable[i] = 0 end
-                                            foundTank = true
-                                        end
-                                    end
-                                end
-                                if not foundTank then
+                                if slottedIndex ~= 0 then
+                                    fuelPercentTable[i] = json.decode(unit[slottedTankType.."_"..slottedIndex].getData()).percentage
+                                    fuelTimeLeftTable[i] = json.decode(unit[slottedTankType.."_"..slottedIndex].getData()).timeLeft
+                                    if fuelTimeLeftTable[i] == "n/a" then fuelTimeLeftTable[i] = 0 end
+                                else
                                     fuelMass = (eleMass(tankTable[i][tankID])-tankTable[i][tankMassEmpty])
                                     fuelMassMax = tankTable[i][tankMaxVol]
-                                    fuelPercentTable[i] = mfloor(fuelMass*100/fuelMassMax)
+                                    fuelPercentTable[i] = mfloor(0.5+fuelMass*100/fuelMassMax)
                                     fuelMassLast = tankTable[i][tankLastMass]
                                     fuelLastTime = tankTable[i][tankLastTime]
                                     if fuelMassLast <= fuelMass then
                                         fuelTimeLeftTable[i] = 0
                                     else
-                                        fuelTimeLeftTable[i] = mfloor(fuelMass / ((fuelMassLast - fuelMass) / (curTime - fuelLastTime)))
+                                        fuelTimeLeftTable[i] = mfloor(0.5+fuelMass / ((fuelMassLast - fuelMass) / (curTime - fuelLastTime)))
                                     end
                                     tankTable[i][tankLastMass] = fuelMass
                                     tankTable[i][tankLastTime] = curTime
@@ -1100,6 +1100,9 @@ handlers:
                             end
                             if name == nameSearchPrefix then 
                                 name = stringf("%s %d", nameReplacePrefix, i)
+                            end
+                            if slottedIndex == 0 then
+                                name = name.." *"
                             end
                             local fuelTimeDisplay
                             if fuelTimeLeftTable[i] == 0 then 


### PR DESCRIPTION
Added individual tank type optimization settings.  Instead of percentage, they go by the level of the skill itself.
Fixed a bug where setting an optimization level would break calculated volume.
Fixed the empty mass of the small space fuel tank.
Fixed a bug where it would always use the data of the first slotted tank.
Fixed a bug where you could not mix slotted and unslotted tanks of the same type.