### PR TITLE
avoid max mass going into some insanely high number

### DIFF
--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -1396,7 +1396,7 @@ handlers:
                     if maxBrake ~= nil then LastMaxBrake = maxBrake end
                     maxThrust = Nav:maxForceForward()
                     totalMass = constructMass()
-                    if gravity > 0 then 
+                    if gravity > 0.1 then 
                         reqThrust = totalMass * gravity
                         maxMass = maxThrust / gravity
                     end
@@ -1413,7 +1413,7 @@ handlers:
                             <text class="txtend" x="1240" y="30">Max Thrust: %.2f kN</text>
                             <text class="txtbig txtmid" x="960" y="360">%s</text>
                         ]], totalDistanceTrip, (totalDistanceTravelled/1000), FormatTimeString(flightTime), FormatTimeString(totalFlightTime), (totalMass/1000), (LastMaxBrake/1000), (maxThrust/1000), flightStyle)
-                        if gravity > 0 then
+                        if gravity > 0.1 then
                             newContent[#newContent + 1] = stringf([[
                                     <text class="txtstart" x="970" y="30">Max Mass: %.2f Tons</text>
                                     <text class="txtend" x="1240" y="20">Req Thrust: %.2f kN</text>

--- a/ButtonHUD.conf
+++ b/ButtonHUD.conf
@@ -253,6 +253,8 @@ handlers:
                 local valuesAreSet = false
                 local doubleCheck = false
                 local totalMass = 0
+                local lastMaxBrakeAtG = nil
+
 
                 -- VARIABLES TO BE SAVED GO HERE
                 SaveableVariables = 
@@ -515,6 +517,18 @@ handlers:
                 unit.hide()
 
                 -- BEGIN FUNCTION DEFINITIONS
+                function refreshLastMaxBrake(gravity, force)
+                    if gravity == nil then gravity = core.g() end
+
+                    gravity = round(gravity, 5) -- round to avoid insignificant updates
+                    if (force ~= nil and force) or (lastMaxBrakeAtG == nil or lastMaxBrakeAtG ~= gravity) then
+                        local maxBrake = jdecode(unit.getData()).maxBrake
+
+                        if maxBrake ~= nil then LastMaxBrake = maxBrake end
+                        lastMaxBrakeAtG = gravity
+                    end
+                end
+
                 function AddLocationsToAtlas() -- Just called once during init really
                     for k,v in pairs(SavedLocations) do
                         table.insert(Atlas,v)
@@ -1392,8 +1406,7 @@ handlers:
                     local gravity = core.g()
                     local massMax = 0
                     local reqThrust = 0
-                    local maxBrake = jdecode(unit.getData()).maxBrake
-                    if maxBrake ~= nil then LastMaxBrake = maxBrake end
+                    refreshLastMaxBrake(gravity)
                     maxThrust = Nav:maxForceForward()
                     totalMass = constructMass()
                     if gravity > 0.1 then 
@@ -2927,13 +2940,8 @@ handlers:
                     -- If we're in atmo, just return some 0's or LastMaxBrake, whatever's bigger
                     -- So we don't do unnecessary API calls when atmo brakes don't tell us what we want
                     if atmosphere() == 0 then
-                        local maxBrake = jdecode(unit.getData()).maxBrake
-                        if maxBrake ~= nil then
-                            LastMaxBrake = maxBrake
-                            return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), 0, 0, maxBrake - (AutopilotPlanetGravity * constructMass()))
-                        else
-                            return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), 0, 0, LastMaxBrake - (AutopilotPlanetGravity * constructMass()))
-                        end
+                        refreshLastMaxBrake()
+                        return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), 0, 0, LastMaxBrake - (AutopilotPlanetGravity * constructMass()))
                     else
                         if LastMaxBrake and LastMaxBrake > 0 then
                             return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), 0, 0, LastMaxBrake - (AutopilotPlanetGravity * constructMass()))
@@ -2944,13 +2952,8 @@ handlers:
                 end
 
                 function GetAutopilotTBBrakeDistanceAndTime(speed) -- Uses thrust and a configured T50
-                    local maxBrake = jdecode(unit.getData()).maxBrake
-                    if maxBrake ~= nil then
-                        LastMaxBrake = maxBrake
-                        return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), Nav:maxForceForward(), warmup, maxBrake - (AutopilotPlanetGravity * constructMass()))
-                    else
-                        return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), Nav:maxForceForward(), warmup, LastMaxBrake - (AutopilotPlanetGravity * constructMass()))
-                    end
+                    refreshLastMaxBrake()
+                    return Kinematic.computeDistanceAndTime(speed, AutopilotEndSpeed, constructMass(), Nav:maxForceForward(), warmup, LastMaxBrake - (AutopilotPlanetGravity * constructMass()))
                 end
 
                 function GetFlightStyle()
@@ -3094,6 +3097,7 @@ handlers:
                     HideInterplanetaryPanel()
                 end
                 checkDamage()
+                refreshLastMaxBrake(nil, true) -- force refresh, in case we took damage
                 updateDistance()
                 if (radar_1 and #radar_1.getEntries() > 0) then
                     local target


### PR DESCRIPTION
this PR contains 2 related commits;

the first one avoids displaying max mass when gravity is so low that it's going into some insanely high number.

the second tries to avoid some `jdecode` calls by not refreshing the maxBrake unless the gravity changed.


I'm not sure yet the second actually improves performance ... but I think it should?  
if you dislike the 2nd commit, just cherry-pick the first, since that's a good fix regardless :D